### PR TITLE
feat: 作業開始前の git-worktree-start skill を追加

### DIFF
--- a/.codex/skills/git-worktree-start/SKILL.md
+++ b/.codex/skills/git-worktree-start/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: git-worktree-start
+description: Prepare a git repository for code changes by syncing the base branch with origin, creating a dedicated worktree, and starting a codex-prefixed branch before editing files. Use when the user asks to implement, fix, refactor, or otherwise modify files in a repository.
+---
+
+# Git Worktree Start
+
+## Overview
+
+Use this skill before making code changes in a git repository. The goal is to start from the latest base branch, isolate the task in a dedicated worktree, and keep the actual work on a `codex/` branch.
+
+## When To Use
+
+- The user asks to implement, fix, refactor, or otherwise change files in a git repository.
+- The task will require edits, tests, commits, or PR work.
+- Skip this skill for read-only investigation, code review, or documentation-only discussion unless the user also wants committed file changes.
+
+## Standard Sequence
+
+1. Identify the repository root, the base branch, and whether the current worktree is clean.
+2. Run `git fetch origin`.
+3. Sync the local base branch to `origin/<base>` before starting the task.
+4. Create a dedicated worktree at a sibling path such as `../<repo>-<task-slug>`.
+5. Create a task branch named `codex/<task-slug>` from `origin/<base>` as part of `git worktree add -b`.
+6. Continue all edits, tests, commits, and PR work inside the new worktree.
+
+## Preferred Commands
+
+Run the setup in this order whenever the repository state allows it:
+
+```sh
+git fetch origin
+git switch <base>
+git pull --ff-only origin <base>
+git worktree add -b codex/<task-slug> ../<repo>-<task-slug> origin/<base>
+```
+
+## Guardrails
+
+- Never use `git reset --hard`, `git checkout --`, or other destructive commands to force the base branch into sync.
+- If the current worktree has uncommitted changes, do not reuse it for the new task. Leave it untouched and find a clean worktree for syncing the base branch.
+- If the base branch cannot be fast-forwarded cleanly, stop and resolve that state before creating the new worktree.
+- If `codex/<task-slug>` already exists, append a numeric suffix such as `codex/<task-slug>-2`.
+- If the target worktree path already exists, choose a new sibling path rather than overwriting it.
+- After setup, explicitly tell the user which absolute worktree path and branch name are being used for the task.
+
+## Notes
+
+- Prefer `origin/<base>` as the starting point for the new branch, even if the local base branch was just updated.
+- If another skill handles the main task afterward, finish this setup first and then continue with that skill in the new worktree.
+
+## Example
+
+```sh
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git worktree add -b codex/fix-login-timeout ../repo-fix-login-timeout origin/main
+```

--- a/.codex/skills/git-worktree-start/agents/openai.yaml
+++ b/.codex/skills/git-worktree-start/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "作業前Git準備"
+  short_description: "変更前に base 同期と worktree/branch 作成を行うスキル"
+  default_prompt: "Use $git-worktree-start before making repository changes to sync the base branch with origin, create a dedicated worktree, and start a codex-prefixed branch for the task."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # 共通
 
 - 回答はすべて日本語で行うこと
+- コード変更を伴う作業では、編集前に必ず `git-worktree-start` skill を使い、`origin/<base>` への同期、専用 worktree の作成、`codex/` プレフィックス付き branch の作成をこの順で実行すること
+- 以後の編集・テスト・コミット・PR 作業は、その worktree 上で継続すること


### PR DESCRIPTION
## 背景
- 要望: コード変更の前に base 同期、専用 worktree 作成、作業 branch 作成を毎回踏む運用を定着させたい
- 責務分離: `gh-pr-ja` は PR 作成段階の skill なので、作業開始前の Git 準備とはタイミングが異なる

## 問題
- 適用タイミング: 実装開始前の手順が既存 skill だと明示されておらず、実行順がぶれやすい
- 運用漏れ: `AGENTS.md` に作業前フローの強制ルールがなく、worktree や branch の切り方が毎回一定にならない

## 対策の方針
- 役割分離: PR 作成とは別に、作業開始専用の `git-worktree-start` skill を追加する
- 強制入口: コード変更前はこの skill を必ず使うルールを `AGENTS.md` に追記する

## 本PRのゴール
- 変更系タスクの開始前に踏む Git 準備手順を skill と `AGENTS.md` の両方で統一する
- `origin/<base>` 同期 -> 専用 worktree 作成 -> `codex/*` branch 作成の標準フローを repo 内で再利用可能にする

## 実際にやったこと
- skill追加: `.codex/skills/git-worktree-start/SKILL.md` を追加し、起動条件・標準手順・guardrail を定義した
- UI定義: `.codex/skills/git-worktree-start/agents/openai.yaml` を追加し、表示名と default prompt を設定した
- 運用ルール: `AGENTS.md` にコード変更前は `git-worktree-start` を必ず使うルールを追記した

## 実行したコマンド
- `git diff --check origin/main...HEAD`: 成功
- `ruby -e 'require "yaml"; data = YAML.load_file(".codex/skills/git-worktree-start/agents/openai.yaml"); abort("missing display_name") unless data.dig("interface", "display_name"); puts data.dig("interface", "display_name")'`: 成功
- `ruby -e 'require "yaml"; text = File.read(".codex/skills/git-worktree-start/SKILL.md"); fm = text[/\A---\n(.*?)\n---\n/m, 1] or abort("frontmatter missing"); data = YAML.safe_load(fm); abort("description missing") unless data["description"] && text.include?("git worktree add -b"); puts data["name"]'`: 成功
- `rg -n "git-worktree-start|worktree|codex/" AGENTS.md .codex/skills/git-worktree-start`: 成功

## 結果
- 成功
- repo 内で `git-worktree-start` skill を起点にした作業前セットアップ手順を明示できる状態になった

## Next Actionの候補
- 命名規則確認: 次回の変更タスクで `task-slug` と worktree path の命名が運用に合うか確認する
- script化検討: branch 名や path 衝突時の suffix 付与まで固定したくなったら、この skill に補助 script を追加する