### PR TITLE
[codex] direnv hook を追加

### DIFF
--- a/.zsh/direnv.zsh
+++ b/.zsh/direnv.zsh
@@ -1,0 +1,6 @@
+# direnv
+# repo ごとの環境変数は .envrc に寄せる。未インストール環境では何もしない。
+if (( $+commands[direnv] )) && [[ -z "${__DOTFILES_DIRENV_HOOK_LOADED:-}" ]]; then
+  eval "$(direnv hook zsh)"
+  __DOTFILES_DIRENV_HOOK_LOADED=1
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -130,4 +130,6 @@ source $HOME/.zsh/alias.zsh
 # gcloud
 [[ -f ~/.zsh/gcloud.zsh ]] && source ~/.zsh/gcloud.zsh
 
+# direnv
+[[ -f ~/.zsh/direnv.zsh ]] && source ~/.zsh/direnv.zsh
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ home ディレクトリの dotfiles をリポジトリに反映
 ```bash
 ./.scripts/copy_to_repo.sh
 ```
+
+## direnv
+
+`direnv` がインストールされている場合だけ、`.zshrc` から `direnv hook zsh` を読み込む。
+
+```bash
+brew install direnv
+```
+
+repo ごとに gcloud の configuration を切り替える場合は、対象 repo の `.envrc` に書く。
+
+```bash
+export CLOUDSDK_ACTIVE_CONFIG_NAME=<config-name>
+export GOOGLE_CLOUD_PROJECT=<project-id>
+export GCLOUD_PROJECT=<project-id>
+```
+
+`.envrc` を確認したうえで有効化する。
+
+```bash
+direnv allow
+```


### PR DESCRIPTION
## 背景
- repo ごとの gcloud configuration 切り替えで direnv を使えるようにする
- dotfiles の `.zshrc` はこの repository で管理している

## 問題
- zsh 起動時に direnv hook が読み込まれないため、repo の `.envrc` に書いた環境変数が自動反映されない

## 対策の方針
- `direnv` がある環境だけ zsh hook を読み込む
- hook 読み込みを `.zsh/direnv.zsh` に分け、`.zshrc` は source だけにする
- gcloud 用 `.envrc` の最小例を README に残す

## 実際にやったこと
- `.zsh/direnv.zsh` を追加
- `.zshrc` から `.zsh/direnv.zsh` を読み込む
- README に `direnv` の install と `.envrc` の例を追加

## 実行したコマンド
- `zsh -n .zshrc` : 成功
- `zsh -n .zsh/direnv.zsh` : 成功
- `zsh -fc 'source .zsh/direnv.zsh; source .zsh/direnv.zsh; [[ "${__DOTFILES_DIRENV_HOOK_LOADED:-}" = 1 ]]'` : 成功
- `git diff --check` : 成功

## 結果
- 成功