### PR TITLE
[codex] BrewfileでHomebrew管理を追加

### DIFF
--- a/.scripts/brew_bundle_apply.sh
+++ b/.scripts/brew_bundle_apply.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DOTFILES_REPO="${DOTFILES_REPO:-$HOME/dev/dotfiles}"
+BREWFILE_PATH="$DOTFILES_REPO/Brewfile"
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "brew が見つかりません。" >&2
+  exit 1
+fi
+
+if [[ ! -f "$BREWFILE_PATH" ]]; then
+  echo "Brewfile が見つかりません: $BREWFILE_PATH" >&2
+  exit 1
+fi
+
+bundle_args=(install --file "$BREWFILE_PATH" --no-upgrade)
+for arg in "$@"; do
+  if [[ "$arg" == "--upgrade" ]]; then
+    bundle_args=(install --file "$BREWFILE_PATH")
+    break
+  fi
+done
+
+brew bundle "${bundle_args[@]}" "$@"

--- a/.scripts/brew_bundle_dump.sh
+++ b/.scripts/brew_bundle_dump.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DOTFILES_REPO="${DOTFILES_REPO:-$HOME/dev/dotfiles}"
+BREWFILE_PATH="$DOTFILES_REPO/Brewfile"
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "brew が見つかりません。" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$BREWFILE_PATH")"
+
+brew bundle dump \
+  --file "$BREWFILE_PATH" \
+  --force \
+  --no-vscode \
+  --no-go \
+  --no-cargo \
+  --no-uv \
+  --no-flatpak \
+  --no-krew \
+  --no-npm \
+  --no-restart \
+  "$@"

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,4 @@
+brew "coreutils"
+brew "direnv"
+brew "gh"
+cask "gcloud-cli"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ home ディレクトリの dotfiles をリポジトリに反映
 ./.scripts/copy_to_repo.sh
 ```
 
+Homebrew で管理するパッケージを `Brewfile` に反映
+
+```bash
+./.scripts/brew_bundle_dump.sh
+```
+
+`Brewfile` に書かれたパッケージを install
+
+```bash
+./.scripts/brew_bundle_apply.sh
+```
+
+upgrade も含めて反映したい場合
+
+```bash
+./.scripts/brew_bundle_apply.sh --upgrade
+```
+
 ## direnv
 
 `direnv` がインストールされている場合だけ、`.zshrc` から `direnv hook zsh` を読み込む。


### PR DESCRIPTION
## 背景
- `brew install` で入れる項目も dotfiles 配下で管理したい
- Homebrew 標準の仕組みに寄せて、独自フォーマットを増やさずに運用したい

## 問題
- Homebrew で入れている formula/cask の一覧がリポジトリで管理されていない
- 新しい環境で同じ Homebrew 構成を再現する手順が README にない

## 対策の方針
- dotfiles 直下に Homebrew 標準の `Brewfile` を置く
- install 用と dump 用の薄いラッパースクリプトだけを `.scripts` に追加する
- 通常の apply では upgrade を走らせず、必要な場合だけ `--upgrade` を明示する

## 実際にやったこと
- `Brewfile` を追加し、現在の Homebrew 管理対象を初期値として記録した
- `./.scripts/brew_bundle_apply.sh` を追加し、`brew bundle install --file ...` を実行できるようにした
- `./.scripts/brew_bundle_dump.sh` を追加し、現在の Homebrew 管理対象を `Brewfile` に書き戻せるようにした
- `README.md` に Homebrew 管理手順を追記した

## 実行したコマンド
- `bash -n .scripts/brew_bundle_apply.sh` : 成功
- `bash -n .scripts/brew_bundle_dump.sh` : 成功
- `brew bundle check --file /Users/na-kobayashi/dev/dotfiles-manage-brewfile/Brewfile` : 成功
- `DOTFILES_REPO=/Users/na-kobayashi/dev/dotfiles-manage-brewfile ./.scripts/brew_bundle_apply.sh` : 成功
- `DOTFILES_REPO=/Users/na-kobayashi/dev/dotfiles-manage-brewfile ./.scripts/brew_bundle_dump.sh` : 成功
- `DOTFILES_REPO=/Users/na-kobayashi/dev/dotfiles-manage-brewfile ./.scripts/brew_bundle_apply.sh --upgrade` : 成功
- `git diff --check --cached` : 成功

## 結果
- 成功
- `Brewfile` を source of truth として Homebrew 管理対象を dotfiles 配下で管理できる状態になった