### PR TITLE
chore: Brewfile に terraform を反映

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,7 @@
+tap "hashicorp/tap"
 brew "coreutils"
 brew "direnv"
 brew "gh"
+brew "node"
+brew "hashicorp/tap/terraform"
 cask "gcloud-cli"


### PR DESCRIPTION
## 背景
- `brew tap hashicorp/tap` と `brew install hashicorp/tap/terraform` を実行したローカル環境を `Brewfile` に反映する必要があった

## 問題
- `Brewfile` に `hashicorp/tap` と `hashicorp/tap/terraform` がなく、Homebrew 管理対象と実環境がずれていた
- dump スクリプト基準では `node` も未反映で、`Brewfile` に drift が残っていた

## 対策の方針
- 既存運用どおり `./.scripts/brew_bundle_dump.sh` で `Brewfile` を再生成する
- 手編集ではなく dump 結果をそのまま採用して、現在の Homebrew 状態と `Brewfile` を一致させる

## 実際にやったこと
- `DOTFILES_REPO=$PWD ./.scripts/brew_bundle_dump.sh` を実行して `Brewfile` を再生成した
- `tap "hashicorp/tap"` を反映した
- `brew "hashicorp/tap/terraform"` を反映した
- dump 結果に含まれた `brew "node"` を反映した

## 実行したコマンド
- `DOTFILES_REPO=$PWD ./.scripts/brew_bundle_dump.sh` : 成功
- `git diff --check` : 成功
- `brew bundle check --file Brewfile` : 成功

## 結果
- 成功
- `Brewfile` が現在の Homebrew 状態と一致した