### PR TITLE
chore: Codex の既定モデルを gpt-5.5 に更新

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,7 +8,7 @@ model_reasoning_effort = "xhigh"
 # Hide internal AI reasoning process to reduce verbose output
 hide_agent_reasoning = true
 
-model = "gpt-5.4"
+model = "gpt-5.5"
 personality = "pragmatic"
 
 # Enable web search functionality


### PR DESCRIPTION
## 背景
- Codex の既定モデルが `gpt-5.4` のままで、利用したい既定値とずれていた

## 問題
- 新しい作業を開始したときに `gpt-5.4` が選ばれ、毎回設定を見直す必要があった

## 対策の方針
- `.codex/config.toml` の `model` だけを更新し、既定モデルを `gpt-5.5` に統一する
- 影響範囲を設定 1 か所に限定し、既存の reasoning 設定や他の挙動は変えない

## 実際にやったこと
- `.codex/config.toml` の `model` を `gpt-5.4` から `gpt-5.5` に変更した
- `.codex` 配下でモデル指定の重複がないことを確認した

## 実行したコマンド
- `git diff --check` : 成功
- `rg -uu -n 'gpt-5\\.4|gpt-5\\.5' .codex` : 成功\n\n## 結果\n- 成功\n- Codex の既定モデルが `gpt-5.5` になった