### PR TITLE
docs: gh-pr-ja にスクショ指示を追加

### DIFF
--- a/.codex/skills/gh-pr-ja/SKILL.md
+++ b/.codex/skills/gh-pr-ja/SKILL.md
@@ -24,8 +24,9 @@ Use these sections in this order unless the user explicitly asks for a different
 2. `問題`
 3. `対策の方針`
 4. `実際にやったこと`
-5. `実行したコマンド`
-6. `結果`
+5. `スクリーンショット`
+6. `実行したコマンド`
+7. `結果`
 
 If a section has no content, omit it. Keep the first four sections whenever they are relevant.
 
@@ -40,6 +41,7 @@ If a section has no content, omit it. Keep the first four sections whenever they
 - In `問題`, describe the broken behavior, missing guardrail, or operational risk. Focus on what was wrong before the change.
 - In `対策の方針`, explain the design choice and the guardrails being introduced. Separate benign cases from real errors when that distinction matters.
 - In `実際にやったこと`, list concrete code, query, config, or test changes. Do not repeat rationale here.
+- If the PR includes UI changes, add a `スクリーンショット` section to the PR description. Attach or paste the screenshot in the description; do not commit screenshot files just to include them in the PR.
 - In `実行したコマンド`, list the exact verification commands and whether each succeeded.
 - In `結果`, state the current state such as `成功`, remaining risk, or follow-up.
 
@@ -49,6 +51,7 @@ If a section has no content, omit it. Keep the first four sections whenever they
    identify the base branch, run `git fetch origin`, and rebase or merge the working branch onto the latest `origin/<base>` using the repository's standard flow. If conflicts appear, resolve them before drafting the PR body or running `gh pr create`. If the base branch advances again while the PR is open, repeat this step before finalizing the PR.
 2. Gather the evidence needed to justify the PR:
    `git diff`, tests, CI results, review comments, incident logs, monitoring links, and latest occurrence timestamps.
+   For UI changes, capture the relevant before/after or after-change screenshots for the PR description without committing those image files.
 3. Decide the title:
    keep it short, in Japanese, and consistent with the repository's commit or PR prefix conventions such as `fix:` or `feat:` when those conventions exist.
 4. Draft the body using the default section order.
@@ -84,6 +87,9 @@ If a section has no content, omit it. Keep the first four sections whenever they
 
 ## 実際にやったこと
 - ...
+
+## スクリーンショット
+![...](...)
 
 ## 実行したコマンド
 - `...` : 成功

--- a/.codex/skills/gh-pr-ja/agents/openai.yaml
+++ b/.codex/skills/gh-pr-ja/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "日本語PR作成"
   short_description: "GitHub PR本文と diff コメントを日本語で整えるスキル"
-  default_prompt: "Use $gh-pr-ja to draft or revise a GitHub PR in Japanese with the required section order, then add concise Japanese intent comments to important diff hunks after the PR is opened."
+  default_prompt: "Use $gh-pr-ja to draft or revise a GitHub PR in Japanese with the required section order, include screenshots in the PR description for UI changes, then add concise Japanese intent comments to important diff hunks after the PR is opened."


### PR DESCRIPTION
## 背景
- `gh-pr-ja` で PR を作るとき、UI 変更がある場合にスクショを PR description に入れる運用を明文化したい
- スクショはレビュー用の補足であり、成果物として commit する必要はない

## 問題
- 既存の PR 作成 skill には UI 変更時のスクショ添付ルールがない
- スクショファイルを commit せず description に載せる、という運用が skill から読み取れない

## 対策の方針
- PR 本文の標準構成に `スクリーンショット` セクションを追加する
- UI 変更時だけスクショを description に添付/貼り付ける指示にして、UI 以外の PR では省略できる形にする
- `agents/openai.yaml` の default prompt も同じ振る舞いに合わせる

## 実際にやったこと
- `.codex/skills/gh-pr-ja/SKILL.md` に `スクリーンショット` セクションと UI 変更時の添付ルールを追加
- スクショファイルは commit せず PR description に入れる指示を追加
- `.codex/skills/gh-pr-ja/agents/openai.yaml` の default prompt を更新

## 実行したコマンド
- `git diff --check` : 成功
- `ruby -e 'require "yaml"; text = File.read(".codex/skills/gh-pr-ja/SKILL.md"); m = text.match(/\A---\n(.*?)\n---\n/m) or abort("missing frontmatter"); YAML.safe_load(m[1], permitted_classes: [Symbol], aliases: true); YAML.load_file(".codex/skills/gh-pr-ja/agents/openai.yaml"); puts "yaml OK"'` : 成功

## 結果
- 成功
